### PR TITLE
Remove a link to Atom feed for uncoded languages (“mis”)

### DIFF
--- a/themes/hugo-planetarium/layouts/index.html
+++ b/themes/hugo-planetarium/layouts/index.html
@@ -7,7 +7,9 @@
         'link[rel=alternate][hreflang]');
       var languages = {};
       langLinks.forEach(function (link) {
-        languages[link.hreflang] = link.href;
+        if (link.type != 'application/atom+xml') {
+          languages[link.hreflang] = link.href;
+        }
       });
       for (var langs = navigator.languages, i = 0; i < langs.length; ++i) {
         var lang = langs[i];

--- a/themes/hugo-planetarium/layouts/partials/header.html
+++ b/themes/hugo-planetarium/layouts/partials/header.html
@@ -26,12 +26,26 @@
       {{ end }}
     {{ end }}
 
-    <link
-      href="{{ .Site.BaseURL }}index.xml"
-      rel="alternate"
-      type="application/atom+xml"
-      title="{{ .Title }}"
-    />
+    {{ if (eq .Site.Language.Lang "mis") }}
+      {{ range .Translations }}
+        {{ if (not (eq .Language.Lang "mis")) }}
+          <link
+            href="{{ .URL }}index.xml"
+            hreflang="{{ .Language.Params.ianasubtag }}"
+            rel="alternate"
+            type="application/atom+xml"
+            title="{{- .Title -}}"
+          />
+        {{ end }}
+      {{ end }}
+    {{ else }}
+      <link
+        href="{{ .Site.BaseURL }}index.xml"
+        rel="alternate"
+        type="application/atom+xml"
+        title="{{ .Title }}"
+      />
+    {{ end }}
 
     {{ partial "head_includes.html" . }}
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
As we are using the language code `mis` (uncoded languages) for the root path, there is no content for this language code.  If a RSS reader takes a URL `https://snack.planetarium.dev/` it tries to scan `link[rel=alternate]` tags that refer to an Atom feed.  This leads RSS readers to subscribe an Atom feed for `mis` which is empty.

This patch fixes this problem by removing a link to an Atom feed for `mis` and adding links to Atom feeds for `eng`/`kor` instead.  (Usually RSS readers let a user choose one of these languages.)