### PR TITLE
Programatically generate Open Graph images

### DIFF
--- a/.github/actions/snack-og-image/Dockerfile
+++ b/.github/actions/snack-og-image/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.9
+
+RUN apk add --no-cache font-noto font-noto-extra imagemagick jq pango
+RUN wget -O /usr/bin/yj \
+  https://github.com/sclevine/yj/releases/download/v3.1.0/yj-linux \
+  && chmod +x /usr/bin/yj
+RUN cd /tmp \
+  && wget \
+  https://noto-website-2.storage.googleapis.com/pkgs/NotoSans-unhinted.zip \
+  https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKkr-hinted.zip \
+  && mkdir -p /usr/share/fonts/noto \
+  && for z in /tmp/NotoSans*.zip; do \
+    unzip \
+      -o \
+      $z \
+      "*Bold*" \
+      -x "*Condensed*" \
+      -x "*Mono*" \
+      -d /usr/share/fonts/noto/; \
+  done \
+  && rm /tmp/NotoSans*.zip
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/snack-og-image/entrypoint.sh
+++ b/.github/actions/snack-og-image/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/ash
+set -e
+mkdir -p static/og
+yj -t < config.toml | jq '.languages' > /tmp/languages.json
+for language in $(jq -r '.|keys|join("\n")' /tmp/languages.json); do
+  jq -r ".$language" /tmp/languages.json > "/tmp/$language.json"
+  if jq -e '.ianaSubtag' "/tmp/$language.json" > /dev/null; then
+    text="$(jq -r '.title' "/tmp/$language.json")"
+    iana="$(jq -r '.ianaSubtag' "/tmp/$language.json")"
+    pango-view \
+      -t "$text" \
+      --no-display \
+      --font='Noto Sans bold 32px' \
+      --language "$iana" \
+      --hinting=full \
+      --margin="50 50 65 90" \
+      --pixels \
+      -o "/tmp/text-$language.png"
+    width="$(identify -format '%w' "/tmp/text-$language.png")"
+    right=$((width-50))
+    convert "/tmp/text-$language.png" \
+      -fill none \
+      -stroke black \
+      -strokewidth 5 \
+      -draw "line 50,100 $right,100" \
+      "/tmp/text-$language.png"
+    composite \
+      -compose multiply \
+      -geometry +50+60 \
+      -density 125 \
+      "themes/hugo-planetarium/static/logo.svg" \
+      "/tmp/text-$language.png" \
+      "static/og/$language.png"
+  fi
+done

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,8 +8,13 @@ action "branch-filter" {
   args = "branch master"
 }
 
+action "snack-og-image" {
+  uses = "./.github/actions/snack-og-image"
+  args = ""
+}
+
 action "hugo-deploy-gh-pages" {
-  needs = "branch-filter"
+  needs = ["branch-filter", "snack-og-image"]
   uses = "khanhicetea/gh-actions-hugo-deploy-gh-pages@master"
   secrets = [
     "GIT_DEPLOY_KEY",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*.swp
 public/
 resources/
+static/og/*.png

--- a/themes/hugo-planetarium/layouts/partials/meta.html
+++ b/themes/hugo-planetarium/layouts/partials/meta.html
@@ -15,12 +15,13 @@
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />
-<meta property="og:image" content="https://planetariumhq.com/assets/img/press/190124.png" />
-<meta property="og:image:type" content="image/png" />
-<meta property="og:image:width" content="" />
-<meta property="og:image:height" content="" />
+{{ if (fileExists (print (print "static/og/" .Site.Language) ".png")) }}
+  <meta property="og:image"
+    content="{{ (print (print "og/" .Site.Language) ".png") | absURL }}" />
+  <meta property="og:image:type" content="image/png" />
+{{ end }}
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:locale" content="{{ .Site.Language }}" />
+<meta property="og:locale" content="{{ .Site.Language.Params.ianaSubtag }}" />
 <meta property="article:published_time"
   content="{{ .Date.Format "2006-01-02" }}">
 <meta property="article:modified_time"


### PR DESCRIPTION
This patch adds a GitHub Action to generate Open Graph images for all languages we support (i.e., `languages` settings in the *config.toml* file).  I used [Noto Sans] for font, [Pango] for text rendering, and [ImageMagick] for composition/SVG rendering.

Rendered images are like below:

![](https://dahlia.github.io/snack.planetarium.dev/og/eng.png)
![](https://dahlia.github.io/snack.planetarium.dev/og/kor.png)

[Noto Sans]: https://www.google.co.kr/get/noto/
[Pango]: https://www.pango.org/
[ImageMagick]: https://www.imagemagick.org/