### PR TITLE
Multiple Open Graph images

### DIFF
--- a/themes/hugo-planetarium/layouts/partials/meta.html
+++ b/themes/hugo-planetarium/layouts/partials/meta.html
@@ -15,10 +15,14 @@
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />
+{{ range .Resources.ByType "image" }}
+{{ if eq .ResourceType "image" }}
+  <meta property="og:image" content="{{ .Permalink }}" />
+{{ end }}
+{{ end }}
 {{ if (fileExists (print (print "static/og/" .Site.Language) ".png")) }}
   <meta property="og:image"
     content="{{ (print (print "og/" .Site.Language) ".png") | absURL }}" />
-  <meta property="og:image:type" content="image/png" />
 {{ end }}
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="{{ .Site.Language.Params.ianaSubtag }}" />


### PR DESCRIPTION
If an article has some attached images its Open Graph metadata will serve these images as well.