### PR TITLE
Fix syntax highlighter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,3 +52,8 @@ posts = "/:year/:month/:filename/"
 [blackfriday]
 extensionsmask = ["noIntraEmphasis", "strikethrough"]
 taskLists = false
+
+[markup.highlight]
+guessSyntax = false
+style = "pastie"
+tabWidth = 8

--- a/content/posts/2020/04/rocksdb/index.kor.md
+++ b/content/posts/2020/04/rocksdb/index.kor.md
@@ -28,13 +28,13 @@ RocksDB는 압축이나 메모리 할당을 위해 또다른 라이브러리들�
 
 이 문제를 해결하기 위해 RocksDB 동적 링크 라이브러리 파일의 [rpath]를 수정하는 방식을 사용했습니다. rpath란 <q>run-time search path</q>를 가리키는 말로, 라이브러리 파일이나 실행 파일 내에 하드코딩 되어서 [동적 링킹][] [로더][]가 해당 파일에서 필요한 라이브러리를 찾기 위한 경로입니다. 처음에는 RocksDB 라이브러리를 빌드할때 rpath를 수정하는 방법을 고려했지만 RocksDB의 빌드 스크립트가 생각보다 복잡해 보였기 때문에 빌드가 완료된 라이브러리 파일의 rpath를 수정하기로 했습니다. 다행히 macOS에서는 [`install_name_tool`], Linux에서는 [`patchelf`]라는 툴로 다음과 같이 간단하게 rpath를 현재 RocksDB 라이브러리가 존재하는 디렉터리로 수정할 수 있습니다.
 
-```
+~~~~ bash
 # macOS
 $ install_name_tool -add-rpath '@loader_path' librocksdb.dylib
 
 # linux
 $ patchelf --set-rpath $ORIGIN librocksdb.so
-```
+~~~~
 
 rpath 수정에 관한 보다 자세한 내용은 제가 참조한 아래 페이지들을 참조하시면 좋을 것 같습니다.
 

--- a/themes/hugo-planetarium/assets/scss/style.scss
+++ b/themes/hugo-planetarium/assets/scss/style.scss
@@ -46,8 +46,10 @@ blockquote p {
 code {
   padding: 2px 4px;
   font-size: 90%;
+}
+
+:not(pre) > code {
   background-color: #eeeeee;
-  /* border-radius: 4px; */
 }
 
 dfn:lang(ko) {

--- a/themes/hugo-planetarium/layouts/partials/head_includes.html
+++ b/themes/hugo-planetarium/layouts/partials/head_includes.html
@@ -10,11 +10,6 @@
   rel="stylesheet" href="{{ $css.Permalink }}"
   integrity="{{ $css.Data.Integrity }}">
 
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/highlightjs@9.12.0/styles/github-gist.css"
-/>
-
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132504786-2"></script>
 <script>

--- a/themes/hugo-planetarium/layouts/partials/scripts.html
+++ b/themes/hugo-planetarium/layouts/partials/scripts.html
@@ -1,5 +1,0 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.14.2/highlight.min.js"></script>
-
-<script>
-  hljs.initHighlightingOnLoad();
-</script>

--- a/themes/hugo-planetarium/theme.toml
+++ b/themes/hugo-planetarium/theme.toml
@@ -4,7 +4,7 @@ licenselink = "https://github.com/siegerts/hugo-theme-basic/blob/master/LICENSE"
 description = "Planetarium's fork of https://github.com/siegerts/hugo-theme-basic"
 homepage = "https://github.com/siegerts/hugo-theme-basic"
 tags = []
-features = ["blog", "blog series", "syntax highlighting", "google analytics", "tachyons"]
+features = ["blog", "blog series", "google analytics", "tachyons"]
 min_version = "0.41"
 
 [author]


### PR DESCRIPTION
We'd used two sorts of syntax highlighters at a time… one is built in Hugo, and other one is highlight.js used by the theme. I removed the latter and fixed some broken styles.