### PR TITLE
Bump cirrus-actions/rebase action version to 1.3

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.2
+      uses: cirrus-actions/rebase@1.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38186#M3250


### PR DESCRIPTION
포크된 저장소의 PR 에서 */rebase* 가 동작하지 않고 있습니다.

https://github.com/planetarium/snack.planetarium.dev/pull/103#issuecomment-628380465
https://github.com/planetarium/snack.planetarium.dev/runs/673257483?check_suite_focus=true



cirrus-actions/rebase 버전을 1.3 으로 올림으로써 포크된 저장소의 PR에서 */rebase* 이 동작하기를 기대합니다.

> Workaround to allow to specify user tokens to support rebases for PRs from forks.
>
> in https://github.com/cirrus-actions/rebase/releases/tag/1.3