### PR TITLE
줄바꿈 스타일 교정

### DIFF
--- a/themes/hugo-planetarium/assets/scss/style.scss
+++ b/themes/hugo-planetarium/assets/scss/style.scss
@@ -88,6 +88,7 @@ figure {
 figcaption {
   font-size: small;
   color: #666;
+  word-break: keep-all;
 }
 figcaption :first-child {
   margin-top: 0;

--- a/themes/hugo-planetarium/assets/scss/style.scss
+++ b/themes/hugo-planetarium/assets/scss/style.scss
@@ -64,6 +64,7 @@ pre {
   line-height: 1.4;
   word-break: break-all;
   word-wrap: break-word;
+  white-space: pre-wrap;
   border: 1px solid #ccc;
   /* border-radius: 4px; */
 }


### PR DESCRIPTION
#120 기고 작업하며 발견한 고치면 좋은 스타일을 알려드립니다.

## 코드 블록 줄바꿈 문제

<img width="476" alt="Screen Shot 2020-10-03 at 11 27 38 PM" src="https://user-images.githubusercontent.com/5278201/95004943-1b861880-062d-11eb-9035-abc39d148e67.png">

`white-space` 속성을 수정해서 해결했습니다. `pre-wrap` 값은 `<pre />`박스의 너비에 맞추어 줄바꿈을 넣어줍니다.

## 이미지 캡션 `keep-all` 스타일

| 이전 | 이후 |
| :--: | :--: |
| <img width="416" alt="Screen Shot 2020-10-03 at 11 17 23 PM" src="https://user-images.githubusercontent.com/5278201/95004961-453f3f80-062d-11eb-9128-4737f88ba851.png"> | <img width="401" alt="Screen Shot 2020-10-03 at 11 17 36 PM" src="https://user-images.githubusercontent.com/5278201/95004965-4f613e00-062d-11eb-99bb-4c19dd285110.png"> |

