### PR TITLE
Better `<table>` style

### DIFF
--- a/themes/hugo-planetarium/assets/scss/style.scss
+++ b/themes/hugo-planetarium/assets/scss/style.scss
@@ -43,6 +43,25 @@ blockquote p {
   display: inline;
 }
 
+blockquote > p:last-child {
+  cite:only-child { display: block; margin-top: 1em; }
+  cite:before { content: '\2014'; } // em dash
+  cite:lang(ko):before { content: '\2014\3008'; } // em dash and opening bracket
+}
+
+table {
+  border-collapse: collapse;
+
+  th, td {
+    border: 1px solid #ccc;
+    padding: 0.5em;
+
+    &:has(> strong:only-child) {
+      background-color: #eee;
+    }
+  }
+}
+
 code {
   font-size: 90%;
 }


### PR DESCRIPTION
Previously, `<table>` had been hazily displayed.  This patch does the minimum adjustments on the style, which looks like below:

<img width="928" alt="Preview" src="https://user-images.githubusercontent.com/12431/190302001-d08987a5-6bcf-46bc-8e1d-441d7fbc3e36.png">

Context: <https://github.com/planetarium/snack.planetarium.dev/pull/153#discussion_r971472102>.