### PR TITLE
Add newlines in blockquotes

### DIFF
--- a/content/posts/2022/09/files-you-would-better-to-know-while-contributing-oss-projects/index.kor.md
+++ b/content/posts/2022/09/files-you-would-better-to-know-while-contributing-oss-projects/index.kor.md
@@ -18,10 +18,13 @@ authors: [hyekyung]
 립플래닛(Libplanet)은 탈중앙 방식으로 멀티플레이 온라인 게임을 만들기 위한 .NET 라이브러리입니다. 이는 전체 게임 플레이가 승인된 중앙 서버가 아닌 동일한 노드 사이의 P2P 네트워크에서 발생하는 것을 의미합니다. 내부적으로 블록체인의 많은 기능(예: 전자 서명, 비잔틴 장애 허용(BFT) 합의, 데이터 복제)을 통합합니다.
 
 > 💡 **립플래닛을 써야하는 3가지 이유**
+> <br><br>
 > ***Embeddable***
 > 게임 앱은 실행 중인 다른 프로세스와 통신할 필요가 없으므로 추가 [마샬링](https://ko.wikipedia.org/wiki/%EB%A7%88%EC%83%AC%EB%A7%81_(%EC%BB%B4%ED%93%A8%ED%84%B0_%EA%B3%BC%ED%95%99)) 또는 프로세스 관리가 필요하지 않습니다. Libplanet은 MySQL이나 PostgreSQL보다 [SQLite](https://ko.wikipedia.org/wiki/SQLite)에 더 가깝습니다.
+> <br><br>
 > ***Isomorphic***
 > Libplanet은 .NET 라이브러리이므로 모든 게임 로직을 동일한 언어인 C#으로 작성하고 블록체인에서 실행할 수 있습니다. [글루 코드](https://en.wikipedia.org/wiki/Glue_code)나 "스마트 계약"이 필요하지 않습니다.
+> <br><br>
 > ***Token-independent***
 > 거의 모든 블록체인 시스템과 달리 사용자가 또 다른 암호 화폐를 만들고 처리하도록 강요하지 않습니다. 당신의 게임은 무료로 플레이할 수 있으며 일반 게이머가 즐길 수 있습니다.
 


### PR DESCRIPTION
This pull request adds `<br>` tags to add new lines in `<blockquote>` for better representation.

In Notion:
<img width="601" alt="Screen Shot 2022-09-21 at 3 24 01 PM" src="https://user-images.githubusercontent.com/26626194/191429575-a490bff0-dab5-4029-8a7d-ebdba3c32c27.png">

Before this pull reqeust:
![image](https://user-images.githubusercontent.com/26626194/191429489-4e84b7c7-e2fa-4fe0-a945-a01f00b69d1a.png)


After this pull request:
![image](https://user-images.githubusercontent.com/26626194/191429396-bd9c49b1-b275-455f-bb85-0bc123ffac9e.png)
