### PR TITLE
Fix title not displayed

### DIFF
--- a/themes/hugo-planetarium/layouts/_default/list.html
+++ b/themes/hugo-planetarium/layouts/_default/list.html
@@ -4,7 +4,7 @@
     href="{{ .Site.BaseURL  }}"
     id="site-title"
     class="b bw1 bb pb1 no-underline dark-gray"
-    >{{ .Site.Title  }}</a
+    >{{ .Site.Params.Title  }}</a
   >
   <section id="main" class="mt5">
     <div>

--- a/themes/hugo-planetarium/layouts/_default/single.html
+++ b/themes/hugo-planetarium/layouts/_default/single.html
@@ -9,7 +9,7 @@
     href="{{ .Site.Home.Permalink }}"
     id="site-title"
     class="b bb bw1 pb1 no-underline dark-gray"
-    >{{ .Site.Title }}</a
+    >{{ .Site.Params.Title }}</a
   >
 
   <section id="main" class="mt5">

--- a/themes/hugo-planetarium/layouts/_default/terms.html
+++ b/themes/hugo-planetarium/layouts/_default/terms.html
@@ -7,7 +7,7 @@
   <a
     href="{{ .Site.BaseURL  }}"
     class="b bw1 bb pb1 no-underline dark-gray"
-    >{{ .Site.Title }}</a
+    >{{ .Site.Params.Title }}</a
   >
   <span class="b"> / </span>
   <!-- prettier-ignore -->

--- a/themes/hugo-planetarium/layouts/index.html
+++ b/themes/hugo-planetarium/layouts/index.html
@@ -24,7 +24,7 @@
     <section id="main">
       <div>
         <h1 id="site-title" class="f3">
-          {{ .Site.Title }}
+          {{ .Site.Params.Title }}
         </h1>
         <ul class="list pl0">
           {{ range .Translations }}

--- a/themes/hugo-planetarium/layouts/partials/meta.html
+++ b/themes/hugo-planetarium/layouts/partials/meta.html
@@ -14,7 +14,7 @@
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="og:title" content="{{ .Title }}" />
-<meta property="og:site_name" content="{{ .Site.Title }}" />
+<meta property="og:site_name" content="{{ .Site.Params.Title }}" />
 {{ if isset site.Params "ogimage" }}
 {{- /* FIXME: restrict them to bring exactly the same resources */ -}}
 <meta property="og:image"
@@ -51,7 +51,7 @@
 <meta name="twitter:creator" content="@{{ .Site.Params.twitter }}" />
 <meta
   name="twitter:title"
-  content="{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Title }}"
+  content="{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Params.Title }}"
 />
 <meta
   name="twitter:description"

--- a/themes/hugo-planetarium/layouts/post/single.html
+++ b/themes/hugo-planetarium/layouts/post/single.html
@@ -7,7 +7,7 @@
 >
   
   <span class="b">/ </span>
-  <a href="{{ .Site.BaseURL  }}" class="b bb bw1 pb1 no-underline dark-gray">{{ .Site.Title }}</a>
+  <a href="{{ .Site.BaseURL  }}" class="b bb bw1 pb1 no-underline dark-gray">{{ .Site.Params.Title }}</a>
   <span class="b"> / </span>
   <a href="/post" class="b bb bw1 pb1 no-underline dark-gray">blog</a>
 

--- a/themes/hugo-planetarium/layouts/project/single.html
+++ b/themes/hugo-planetarium/layouts/project/single.html
@@ -10,7 +10,7 @@
   <a
     href="{{ .Site.BaseURL  }}"
     class="b bb bw1 pb1 no-underline dark-gray"
-    >{{ .Site.Title }}</a
+    >{{ .Site.Params.Title }}</a
   >
 
   <section id="main" class="mt5">

--- a/themes/hugo-planetarium/layouts/taxonomy/category.html
+++ b/themes/hugo-planetarium/layouts/taxonomy/category.html
@@ -7,7 +7,7 @@
   <a
     href="{{ .Site.BaseURL  }}"
     class="b bw1 bb pb1 no-underline dark-gray"
-    >{{ .Site.Title  }}</a
+    >{{ .Site.Params.Title  }}</a
   >
   <span class="b"> / </span>
   <a href="/categories" class="b bw1 bb pb1 no-underline dark-gray">categories</a>

--- a/themes/hugo-planetarium/layouts/taxonomy/series.html
+++ b/themes/hugo-planetarium/layouts/taxonomy/series.html
@@ -7,7 +7,7 @@
   <a
     href="{{ .Site.BaseURL  }}"
     class="b bw1 bb pb1 no-underline dark-gray"
-    >{{ .Site.Title  }}</a
+    >{{ .Site.Params.Title  }}</a
   >
   <span class="b"> / </span>
   <a href="/series" class="b bw1 bb pb1 no-underline dark-gray">series</a>

--- a/themes/hugo-planetarium/layouts/taxonomy/tag.html
+++ b/themes/hugo-planetarium/layouts/taxonomy/tag.html
@@ -7,7 +7,7 @@
   <a
     href="{{ .Site.BaseURL  }}"
     class="b bw1 bb pb1 no-underline dark-gray"
-    >{{ .Site.Title  }}</a
+    >{{ .Site.Params.Title  }}</a
   >
   <span class="b"> / </span>
   <a href="/tags" class="b bw1 bb pb1 no-underline dark-gray">tags</a>


### PR DESCRIPTION
Since https://github.com/planetarium/snack.planetarium.dev/pull/191, the title has disappeared. It would be because I changed `languages.kor` to `languages.kor.params` because of Hugo's deprecation. I tried using `.Site.Params.Title` instead of `.Site.Title` , it seems to work.

- Before: https://web.archive.org/web/20240224180558/https://snack.planetarium.dev/kor/
<img width="969" alt="image" src="https://github.com/user-attachments/assets/d4d3a543-2099-49d5-a400-a93b346c832f">

- Now: https://snack.planetarium.dev/kor/
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/dd51ad51-7a63-496d-a63a-e7548ca0ced5">

- After this PR: 
<img width="955" alt="image" src="https://github.com/user-attachments/assets/1abecb34-c939-41f2-b3ac-bc0f87083dad">
