### PR TITLE
fix: show translations links

### DIFF
--- a/themes/hugo-planetarium/layouts/_default/single.html
+++ b/themes/hugo-planetarium/layouts/_default/single.html
@@ -27,7 +27,7 @@
             <a href="{{ .Permalink }}"
               hreflang="{{ .Language.Params.ianasubtag }}"
               title="{{- .Title -}}"
-              class="gray">{{ .Language.LanguageName }}</a>
+              class="gray">{{ .Language.Params.LanguageName }}</a>
           {{- end -}}
         {{- end -}}
         )


### PR DESCRIPTION
## Before

https://snack.planetarium.dev/eng/2019/11/looking-back-at-hacktoberfest/

<img width="1039" alt="Screenshot 2024-10-29 at 5 29 46 PM" src="https://github.com/user-attachments/assets/a52e2e17-5b1e-4c3e-b2d1-71ed1e5162e8">

## After

In my localhost:

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/03715d22-97e8-4aab-87bf-95e847d93999">
