### PR TITLE
Update GitHub social info to current username

### DIFF
--- a/data/authors/muhun.kim.toml
+++ b/data/authors/muhun.kim.toml
@@ -5,5 +5,5 @@ name = "김무훈"
 name = "Muhun Kim"
 
 [social]
-github = "x86chi"
+github = "mu-hun"
 email = "iam@muhun.kim"


### PR DESCRIPTION
다시 오랜만입니다.

개인 포트폴리오 점검 중에 변경했던 GitHub 유저네임이 플라네타리움 스낵에 누락된 걸 확인되어 수정 요청드립니다. 🙇🏻 