### PR TITLE
update copyright

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://snack.planetarium.dev/"
 theme = "hugo-planetarium"
 copyright = '''
-    &copy; 2019&ndash;2023
+    &copy; 2019&ndash;2025
     <a href="https://planetariumlabs.com/"
         style="color: inherit; text-decoration: inherit;">Planetarium</a>.
 '''


### PR DESCRIPTION
This pull request includes a small change to the `config.toml` file. The change updates the copyright year range.

* [`config.toml`](diffhunk://#diff-28043ff911f28a5cb5742f7638363546311225a63eabc365af5356c70d4deb77L4-R4): Updated the copyright year range from 2019–2023 to 2019–2025.